### PR TITLE
Refactor command-related classes and remove redundant attributes

### DIFF
--- a/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using UpHateblo.Lib.Commands;
 using UpHateblo.Lib.Entities;
 
 namespace UpHateblo.Lib.Tests.Commands;
@@ -32,28 +33,28 @@ public class PostEntryCommandTests : CommandTestsBase<PostEntryCommandSecrets>
     [Fact]
     public async Task ItCanPostEntry()
     {
-        await EntryCommands.Post(HttpClient, Blog, CustomPathRandomizedEntry);
+        await PostEntryCommand.Run(HttpClient, Blog, CustomPathRandomizedEntry);
     }
 
     [Fact]
     public async Task ItCanPostProductionEntry()
     {
         var entry = CustomPathRandomizedEntry with { Draft = false };
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 
     [Fact(Skip = "プレビューフラグをオンにして投稿した結果がどのようなものになるか私がよくわかっていない")]
     public async Task ItCanPostPreviewEntry()
     {
         var entry = CustomPathRandomizedEntry with { Preview = true };
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 
     [Fact]
     public async Task ItCanPostMultipleCategoryEntry()
     {
         var entry = CustomPathRandomizedEntry with { Category = ["技術", "Test"] };
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 
     /// <summary>
@@ -64,8 +65,8 @@ public class PostEntryCommandTests : CommandTestsBase<PostEntryCommandSecrets>
     public async Task ItCanPostOnSameUrlPath()
     {
         var entry = CustomPathRandomizedEntry;
-        await EntryCommands.Post(HttpClient, Blog, entry);
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 
     /// <summary>
@@ -77,13 +78,13 @@ public class PostEntryCommandTests : CommandTestsBase<PostEntryCommandSecrets>
     public async Task ItCanPostOnEmptyUrlPath()
     {
         var entry = CustomPathRandomizedEntry with { CustomPath = "" };
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 
     [Fact]
     public async Task ItCanPostWhenUrlPathIsNull()
     {
         var entry = CustomPathRandomizedEntry with { CustomPath = null };
-        await EntryCommands.Post(HttpClient, Blog, entry);
+        await PostEntryCommand.Run(HttpClient, Blog, entry);
     }
 }

--- a/UpHateblo.Lib/Commands/CommandHelper.cs
+++ b/UpHateblo.Lib/Commands/CommandHelper.cs
@@ -1,0 +1,26 @@
+using UpHateblo.Lib.Entities;
+using UpHateblo.Lib.Http;
+using UpHateblo.Lib.Schema;
+
+namespace UpHateblo.Lib.Commands;
+
+internal static class CommandHelper
+{
+    public static HatenaContent GenHatenaContent(
+        EntrySchemaBase? schema,
+        BlogConfig blog,
+        Entry entry,
+        string? wsseNonce = null,
+        DateTime? wsseDateTime = null
+    )
+    {
+        var xml = schema?.Serialize(blog, entry);
+        var wsse = new Wsse(
+            blog.Username,
+            blog.Password,
+            wsseNonce ?? Guid.CreateVersion7().ToString(),
+            wsseDateTime ?? DateTime.Now
+        );
+        return new HatenaContent(xml, wsse);
+    }
+}

--- a/UpHateblo.Lib/Commands/PostEntryCommand.cs
+++ b/UpHateblo.Lib/Commands/PostEntryCommand.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
 using UpHateblo.Lib.Entities;
 using UpHateblo.Lib.Schema;
 
 namespace UpHateblo.Lib.Commands;
 
-[SuppressMessage("ReSharper", "UnusedType.Global")]
-[SuppressMessage("ReSharper", "UnusedMember.Global")]
 public static class PostEntryCommand
 {
     private static readonly PostEntrySchema PostEntrySchema = new();

--- a/UpHateblo.Lib/Commands/PostEntryCommand.cs
+++ b/UpHateblo.Lib/Commands/PostEntryCommand.cs
@@ -3,15 +3,15 @@ using UpHateblo.Lib.Entities;
 using UpHateblo.Lib.Http;
 using UpHateblo.Lib.Schema;
 
-namespace UpHateblo.Lib;
+namespace UpHateblo.Lib.Commands;
 
 [SuppressMessage("ReSharper", "UnusedType.Global")]
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
-public static class EntryCommands
+public static class PostEntryCommand
 {
     private static readonly PostEntrySchema PostEntrySchema = new();
 
-    public static async Task Post(
+    public static async Task Run(
         HttpClient httpClient,
         BlogConfig blog,
         Entry entry,

--- a/UpHateblo.Lib/Commands/PostEntryCommand.cs
+++ b/UpHateblo.Lib/Commands/PostEntryCommand.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using UpHateblo.Lib.Entities;
-using UpHateblo.Lib.Http;
 using UpHateblo.Lib.Schema;
 
 namespace UpHateblo.Lib.Commands;
@@ -20,26 +19,8 @@ public static class PostEntryCommand
     )
     {
         var httpContent =
-            GenHatenaContent(PostEntrySchema, blog, entry, wsseNonce, wsseDateTime);
+            CommandHelper.GenHatenaContent(PostEntrySchema, blog, entry, wsseNonce, wsseDateTime);
         var res = await httpClient.PostAsync(blog.EntryEndPoint, httpContent);
         res.EnsureSuccessStatusCode();
-    }
-
-    private static HatenaContent GenHatenaContent(
-        EntrySchemaBase? schema,
-        BlogConfig blog,
-        Entry entry,
-        string? wsseNonce = null,
-        DateTime? wsseDateTime = null
-    )
-    {
-        var xml = schema?.Serialize(blog, entry);
-        var wsse = new Wsse(
-            blog.Username,
-            blog.Password,
-            wsseNonce ?? Guid.CreateVersion7().ToString(),
-            wsseDateTime ?? DateTime.Now
-        );
-        return new HatenaContent(xml, wsse);
     }
 }


### PR DESCRIPTION
- Removed unnecessary `SuppressMessage` attribute from `PostEntryCommand`.
- Moved `GenHatenaContent` functionality into a new `CommandHelper` class for better modularity.
- Created a new `PostEntryCommand` class and separated it from `EntryCommands` for improved maintainability.