### PR TITLE
Update `Entry` entity with Equatable implementation and new properties

### DIFF
--- a/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
@@ -19,6 +19,7 @@ public class PostEntryCommandTests : CommandTestsBase<BlogConfigSecrets>
         複数行
         """,
         "test-path",
+        EntryId: null,
         true
     );
 

--- a/UpHateblo.Lib.Tests/Entities/EntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entities/EntryTests.cs
@@ -1,0 +1,69 @@
+using UpHateblo.Lib.Entities;
+
+namespace UpHateblo.Lib.Tests.Entities;
+
+public class EntryTests
+{
+    // Use a fixed date for deterministic tests
+    private static readonly DateTime FixedDate =
+        DateTime.Parse("2023-10-27T10:00:00Z").ToUniversalTime();
+
+    [Fact]
+    public void EqualsWhenHashSetInstancesAreDifferentButContentsAreSame()
+    {
+        // Arrange
+        var entry1 = new Entry(
+            "Title",
+            ["tech", "c#"],
+            FixedDate,
+            "Content",
+            "/url",
+            "entry-id",
+            false,
+            false
+        );
+        var entry2 = new Entry(
+            "Title",
+            ["c#", "tech"], // Order does not matter for HashSet
+            FixedDate,
+            "Content",
+            "/url",
+            "entry-id",
+            false,
+            false
+        );
+
+        // Act & Assert
+        Assert.Equal(entry1, entry2);
+        Assert.Equal(entry1.GetHashCode(), entry2.GetHashCode());
+    }
+
+    [Fact]
+    public void NotEqualsWhenHashSetContentsDiffer()
+    {
+        // Arrange
+        var entry1 = new Entry(
+            "Title",
+            ["tech", "c#"],
+            FixedDate,
+            "Content",
+            "/url",
+            "entry-id",
+            false,
+            false
+        );
+        var entry2 = new Entry(
+            "Title",
+            ["tech", "dotnet"],
+            FixedDate,
+            "Content",
+            "/url",
+            "entry-id",
+            false,
+            false
+        );
+
+        // Act & Assert
+        Assert.NotEqual(entry1, entry2);
+    }
+}

--- a/UpHateblo.Lib/Entities/Entry.cs
+++ b/UpHateblo.Lib/Entities/Entry.cs
@@ -6,6 +6,7 @@ public record Entry(
     DateTime Date,
     string Content,
     string? CustomPath,
+    string? EntryId,
     bool? Draft = null,
     bool? Preview = null
 );

--- a/UpHateblo.Lib/Entities/Entry.cs
+++ b/UpHateblo.Lib/Entities/Entry.cs
@@ -1,8 +1,11 @@
+using Equatable.Attributes;
+
 namespace UpHateblo.Lib.Entities;
 
-public record Entry(
+[Equatable]
+public partial record Entry(
     string Title,
-    string[] Category,
+    [property: SequenceEquality] string[] Category,
     DateTime Date,
     string Content,
     string? CustomPath,

--- a/UpHateblo.Lib/Entities/Entry.cs
+++ b/UpHateblo.Lib/Entities/Entry.cs
@@ -5,7 +5,7 @@ namespace UpHateblo.Lib.Entities;
 [Equatable]
 public partial record Entry(
     string Title,
-    [property: SequenceEquality] string[] Category,
+    [property: HashSetEquality] HashSet<string> Category,
     DateTime Date,
     string Content,
     string? CustomPath,


### PR DESCRIPTION
---

### Summary

This pull request introduces several enhancements to the `Entry` entity:

1. **Equatable Implementation**:  
   - Added Equatable attributes to enable comparison between `Entry` instances.
   - Applied appropriate equality behavior for the `Category` property using `SequenceEquality`.

2. **Property Updates**:  
   - Changed the `Category` property type to `HashSet` for improved uniqueness handling.
   - Added an `EntryId` property to uniquely identify entries.

3. **Tests**:  
   - Added tests to verify `Equals` and hash-based behaviors of the `Entry` entity.
   - Updated `PostEntryCommandTests` to reflect the `EntryId` property changes.

---

### Checklist

- [ ] Code changes are fully tested.
- [ ] Documentation and annotations are updated where applicable.
- [ ] Changes do not break existing functionality.