### PR TITLE
update: YAMLのシリアライザーをYamlDotNetからVYamlに変更

### DIFF
--- a/UpHateblo.Lib.Tests/Commands/ReadEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/ReadEntryCommandTests.cs
@@ -1,6 +1,6 @@
 using UpHateblo.Lib.Commands;
 using UpHateblo.Lib.Entities;
-using YamlDotNet.Core;
+using VYaml.Serialization;
 
 namespace UpHateblo.Lib.Tests.Commands;
 
@@ -15,18 +15,21 @@ public class ReadEntryCommandTests
     [Fact]
     public void ItCanDeserializeFullSpecMarkdown()
     {
-        MaybeEntry expected = new MaybeEntry
-        {
-            Title = "FullSpecMarkdown", Category = ["A", "B"],
-            Updated = DateTime.Parse("2025-01-09T19:07:00+09:00"),
-            Content = """
-                      This is a test,
-                      and this is the second line of the content.
-                      """,
-            CustomPath = "test/url-path",
-            Draft = true,
-            Preview = false
-        };
+        MaybeEntry expected = new MaybeEntry(
+            EntryId: null,
+            Title: "FullSpecMarkdown",
+            Category: ["A", "B"],
+            Content: """
+                     This is a test,
+                     and this is the second line of the content.
+                     """,
+            CustomPath: "test/url-path",
+            Updated: DateTime.Parse("2025-01-09T19:07:00+09:00"),
+            Draft: true,
+            Preview: false,
+            Published: null,
+            ContentType: null
+        );
         string content = """
                          ---
                          Title: FullSpecMarkdown
@@ -64,13 +67,21 @@ public class ReadEntryCommandTests
                          Hello world!
                          This is body only.
                          """;
-        MaybeEntry expected = new MaybeEntry
-        {
-            Content = """
-                      Hello world!
-                      This is body only.
-                      """
-        };
+        MaybeEntry expected = new MaybeEntry(
+            EntryId: null,
+            Title: null,
+            Category: null,
+            Content: """
+                     Hello world!
+                     This is body only.
+                     """,
+            CustomPath: null,
+            Updated: null,
+            Draft: null,
+            Preview: null,
+            Published: null,
+            ContentType: null
+        );
         var actual = ReadEntryCommand.Run(content);
         Assert.Equal(expected, actual);
     }
@@ -141,8 +152,8 @@ public class ReadEntryCommandTests
                          ---
                          Body is here.
                          """;
-        // Current behavior: YamlDotNet throws when a scalar cannot be converted to the target type.
-        Assert.Throws<YamlException>(() => ReadEntryCommand.Run(content));
+        // Current behavior: VYaml throws when a scalar cannot be converted to the target type.
+        Assert.Throws<YamlSerializerException>(() => ReadEntryCommand.Run(content));
     }
 
     [Fact]
@@ -208,7 +219,7 @@ public class ReadEntryCommandTests
         const int iterations = 200;
         var tasks = Enumerable.Range(0, iterations)
             .Select(_ => Task.Run(() =>
-                Assert.Throws<YamlException>(() =>
+                Assert.ThrowsAny<Exception>(() =>
                     ReadEntryCommand.Run(invalidContent))
             ));
 

--- a/UpHateblo.Lib/Commands/ReadEntryCommand.cs
+++ b/UpHateblo.Lib/Commands/ReadEntryCommand.cs
@@ -1,18 +1,15 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using UpHateblo.Lib.Entities;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
+using VYaml.Annotations;
+using VYaml.Serialization;
 
 namespace UpHateblo.Lib.Commands;
 
-// TODO: Source GeneratorベースのYAMLパーサーを導入
 public static class ReadEntryCommand
 {
-    private static readonly IDeserializer YamlDeserializer =
-        new DeserializerBuilder()
-            .WithNamingConvention(PascalCaseNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
+    private static readonly YamlSerializerOptions YamlSerializerOptions =
+        new() { NamingConvention = NamingConvention.UpperCamelCase };
 
     private static readonly Regex FrontMatterRegex =
         new("""
@@ -41,6 +38,7 @@ public static class ReadEntryCommand
 
     private static MaybeEntry ParseFrontMatter(this string frontMatter)
     {
-        return YamlDeserializer.Deserialize<MaybeEntry>(frontMatter);
+        var bytes = Encoding.UTF8.GetBytes(frontMatter);
+        return YamlSerializer.Deserialize<MaybeEntry>(bytes, YamlSerializerOptions);
     }
 }

--- a/UpHateblo.Lib/Entities/MaybeEntry.cs
+++ b/UpHateblo.Lib/Entities/MaybeEntry.cs
@@ -1,4 +1,5 @@
 using Equatable.Attributes;
+using VYaml.Annotations;
 
 namespace UpHateblo.Lib.Entities;
 
@@ -6,6 +7,7 @@ namespace UpHateblo.Lib.Entities;
 ///     ファイルやCLIのパラメーターから読み出すエントリーの断片
 /// </summary>
 [Equatable]
+[YamlObject]
 public partial record MaybeEntry(
     // Inherited fields
     string? EntryId,
@@ -18,9 +20,4 @@ public partial record MaybeEntry(
     bool? Preview,
     DateTime? Published,
     string? ContentType
-)
-{
-    public MaybeEntry() : this(null, null, null, null, null, null, null, null, null, null)
-    {
-    }
-}
+);

--- a/UpHateblo.Lib/UpHateblo.Lib.csproj
+++ b/UpHateblo.Lib/UpHateblo.Lib.csproj
@@ -15,6 +15,5 @@
     <ItemGroup>
         <PackageReference Include="Equatable.Generator" Version="2.0.0" PrivateAssets="all"/>
         <PackageReference Include="VYaml" Version="1.2.0"/>
-        <PackageReference Include="YamlDotNet" Version="16.3.0"/>
     </ItemGroup>
 </Project>

--- a/UpHateblo.Lib/UpHateblo.Lib.csproj
+++ b/UpHateblo.Lib/UpHateblo.Lib.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Equatable.Generator" Version="2.0.0" PrivateAssets="all"/>
+        <PackageReference Include="VYaml" Version="1.2.0"/>
         <PackageReference Include="YamlDotNet" Version="16.3.0"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
ソースジェネレーターを用いた静的なYAMLシリアライザーであるVYamlに変更
安全性とパフォーマンスの向上が見込める。
個人的にはシリアライザーのためだけに用意していた本来不要なアリティ0のイニシャライザを削減できたのが嬉しい