### PR TITLE
update: UpdatedプロパティをDateに命名を変更

### DIFF
--- a/UpHateblo.Lib.Tests/Commands/EditEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/EditEntryCommandTests.cs
@@ -20,7 +20,7 @@ public class EditEntryCommandTests : WebRequestTestBase
                       Updated at {updated}
                       """,
             CustomPath: null,
-            Updated: updated,
+            Date: updated,
             Draft: true,
             Preview: false
         );

--- a/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/PostEntryCommandTests.cs
@@ -19,7 +19,7 @@ public class PostEntryCommandTests : WebRequestTestBase
                       Posted at {updated}
                       """,
             CustomPath: null,
-            Updated: updated,
+            Date: updated,
             Draft: true,
             Preview: false
         );

--- a/UpHateblo.Lib.Tests/Commands/ReadEntryCommandTests.cs
+++ b/UpHateblo.Lib.Tests/Commands/ReadEntryCommandTests.cs
@@ -24,7 +24,7 @@ public class ReadEntryCommandTests
                      and this is the second line of the content.
                      """,
             CustomPath: "test/url-path",
-            Updated: DateTime.Parse("2025-01-09T19:07:00+09:00"),
+            Date: DateTime.Parse("2025-01-09T19:07:00+09:00"),
             Draft: true,
             Preview: false,
             Published: null,
@@ -36,7 +36,7 @@ public class ReadEntryCommandTests
                          Category: 
                            - A
                            - B
-                         Updated: 2025-01-09T19:07:00+09:00
+                         Date: 2025-01-09T19:07:00+09:00
                          CustomPath: test/url-path
                          Draft: true
                          Preview: false
@@ -76,7 +76,7 @@ public class ReadEntryCommandTests
                      This is body only.
                      """,
             CustomPath: null,
-            Updated: null,
+            Date: null,
             Draft: null,
             Preview: null,
             Published: null,
@@ -114,7 +114,7 @@ public class ReadEntryCommandTests
         var actual = ReadEntryCommand.Run(content);
         Assert.Null(actual.Title);
         Assert.Null(actual.Category);
-        Assert.Null(actual.Updated);
+        Assert.Null(actual.Date);
         Assert.Equal("""
                      ---
                      Title: ShouldNotBeParsed
@@ -146,7 +146,7 @@ public class ReadEntryCommandTests
         string content = """
                          ---
                          Title: HasInvalids
-                         Updated: not-a-date
+                         Date: not-a-date
                          Draft: not-a-bool
                          Preview: maybe
                          ---
@@ -166,7 +166,7 @@ public class ReadEntryCommandTests
                           Category: 
                             - A
                             - B
-                          Updated: 2025-01-09T19:07:00+09:00
+                          Date: 2025-01-09T19:07:00+09:00
                           CustomPath: test/url-path
                           Draft: true
                           Preview: false

--- a/UpHateblo.Lib.Tests/Entities/EditableEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entities/EditableEntryTests.cs
@@ -10,7 +10,7 @@ public class EditableEntryTests
         Category: ["tech", "c#"],
         Content: "Content",
         CustomPath: "/url",
-        Updated: DateTime.Parse("2023-10-01"),
+        Date: DateTime.Parse("2023-10-01"),
         Draft: false,
         Preview: false
     );

--- a/UpHateblo.Lib.Tests/Entities/EntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entities/EntryTests.cs
@@ -9,7 +9,7 @@ public class EntryTests
         Category: ["tech", "c#"],
         Content: "Content",
         CustomPath: "/url",
-        Updated: DateTime.Parse("2023-10-01"),
+        Date: DateTime.Parse("2023-10-01"),
         Draft: false,
         Preview: false
     );

--- a/UpHateblo.Lib.Tests/Entities/FetchedEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entities/FetchedEntryTests.cs
@@ -10,7 +10,7 @@ public class FetchedEntryTests
         Category: ["tech", "c#"],
         Content: "Test content",
         AbsoluteCustomPath: "/test/custom/path",
-        AbsoluteUpdated: DateTime.Parse("2023-10-02"),
+        AbsoluteDate: DateTime.Parse("2023-10-02"),
         AbsoluteDraft: false,
         AbsolutePreview: false,
         Published: DateTime.Parse("2023-10-01"),

--- a/UpHateblo.Lib.Tests/Entities/MaybeEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entities/MaybeEntryTests.cs
@@ -10,7 +10,7 @@ public class MaybeEntryTests
         Category: ["tech", "c#"],
         Content: "Content",
         CustomPath: "/url",
-        Updated: DateTime.Parse("2023-10-02"),
+        Date: DateTime.Parse("2023-10-02"),
         Draft: false,
         Preview: false,
         Published: DateTime.Parse("2023-10-01"),

--- a/UpHateblo.Lib.Tests/Schema/FetchedEntrySchemaTest.cs
+++ b/UpHateblo.Lib.Tests/Schema/FetchedEntrySchemaTest.cs
@@ -118,7 +118,7 @@ public class FetchedEntrySchemaTest
                          Second line.
                          """, entry.Content);
             Assert.Equal("01998a00-4a65-7eb1-9d79-ddb822fc17b5", entry.AbsoluteCustomPath);
-            Assert.Equal(DateTime.Parse("2023-01-01T00:00:00+09:00"), entry.AbsoluteUpdated);
+            Assert.Equal(DateTime.Parse("2023-01-01T00:00:00+09:00"), entry.AbsoluteDate);
             Assert.True(entry.AbsoluteDraft);
             Assert.True(entry.AbsolutePreview);
             Assert.Equal(DateTime.Parse("2022-09-27T15:55:17+09:00"), entry.Published);

--- a/UpHateblo.Lib.Tests/Schema/PostingEntrySchemaTests.cs
+++ b/UpHateblo.Lib.Tests/Schema/PostingEntrySchemaTests.cs
@@ -20,7 +20,7 @@ public class PostingEntrySchemaTests
                      Second line.
                      """,
             CustomPath: "test/custom/path",
-            Updated: DateTime.Parse("2025-09-23T21:29:00"),
+            Date: DateTime.Parse("2025-09-23T21:29:00"),
             Draft: true,
             Preview: false
         );
@@ -59,7 +59,7 @@ public class PostingEntrySchemaTests
                      Second line.
                      """,
             CustomPath: null,
-            Updated: null,
+            Date: null,
             Draft: null,
             Preview: null
         );

--- a/UpHateblo.Lib/Entities/EditableEntry.cs
+++ b/UpHateblo.Lib/Entities/EditableEntry.cs
@@ -11,7 +11,7 @@ public partial record EditableEntry(
     HashSet<string> Category,
     string Content,
     string? CustomPath,
-    DateTime? Updated,
+    DateTime? Date,
     bool? Draft,
     bool? Preview
-) : Entry(Title, Category, Content, CustomPath, Updated, Draft, Preview);
+) : Entry(Title, Category, Content, CustomPath, Date, Draft, Preview);

--- a/UpHateblo.Lib/Entities/Entry.cs
+++ b/UpHateblo.Lib/Entities/Entry.cs
@@ -8,7 +8,7 @@ public partial record Entry(
     [property: HashSetEquality] HashSet<string> Category,
     string Content,
     string? CustomPath,
-    DateTime? Updated,
+    DateTime? Date,
     bool? Draft,
     bool? Preview
 );

--- a/UpHateblo.Lib/Entities/FetchedEntry.cs
+++ b/UpHateblo.Lib/Entities/FetchedEntry.cs
@@ -13,11 +13,11 @@ public partial record FetchedEntry(
     string Content,
     // Fields that have been made non-nullable from optional fields in the base class
     string AbsoluteCustomPath,
-    DateTime AbsoluteUpdated,
+    DateTime AbsoluteDate,
     bool AbsoluteDraft,
     bool AbsolutePreview,
     // Newly defined fields
     DateTime Published,
     string ContentType
-) : EditableEntry(EntryId, Title, Category, Content, AbsoluteCustomPath, AbsoluteUpdated,
+) : EditableEntry(EntryId, Title, Category, Content, AbsoluteCustomPath, AbsoluteDate,
     AbsoluteDraft, AbsolutePreview);

--- a/UpHateblo.Lib/Entities/MaybeEntry.cs
+++ b/UpHateblo.Lib/Entities/MaybeEntry.cs
@@ -14,7 +14,7 @@ public partial record MaybeEntry(
     [property: HashSetEquality] HashSet<string>? Category,
     string? Content,
     string? CustomPath,
-    DateTime? Updated,
+    DateTime? Date,
     bool? Draft,
     bool? Preview,
     DateTime? Published,

--- a/UpHateblo.Lib/Entities/MaybeEntry.cs
+++ b/UpHateblo.Lib/Entities/MaybeEntry.cs
@@ -9,7 +9,6 @@ namespace UpHateblo.Lib.Entities;
 [Equatable]
 [YamlObject]
 public partial record MaybeEntry(
-    // Inherited fields
     string? EntryId,
     string? Title,
     [property: HashSetEquality] HashSet<string>? Category,

--- a/UpHateblo.Lib/Schema/FetchedEntrySchema.cs
+++ b/UpHateblo.Lib/Schema/FetchedEntrySchema.cs
@@ -24,7 +24,7 @@ internal static class FetchedEntrySchema
                 Category: entryElement.ParseCategory(),
                 Content: content,
                 AbsoluteCustomPath: entryElement.ParseCustomPath(),
-                AbsoluteUpdated: entryElement.ParseUpdated(),
+                AbsoluteDate: entryElement.ParseUpdated(),
                 AbsoluteDraft: entryElement.ParseDraft(),
                 AbsolutePreview: entryElement.ParseAbsolutePreview(),
                 Published: entryElement.ParsePublished(),

--- a/UpHateblo.Lib/Schema/PostingEntrySchema.cs
+++ b/UpHateblo.Lib/Schema/PostingEntrySchema.cs
@@ -24,8 +24,8 @@ internal static class PostingEntrySchema
                     new XAttribute("type", "text/plain"),
                     new XText(entry.Content)
                 ),
-                entry.Updated is not null
-                    ? new XElement(AtomNs + "updated", entry.Updated)
+                entry.Date is not null
+                    ? new XElement(AtomNs + "updated", entry.Date)
                     : null,
                 entry.Category.Select(c => new XElement(AtomNs + "category",
                     new XAttribute("term", c))),


### PR DESCRIPTION
blogsyncに合わせた命名のほうがやはりいいだろうと方針を変更した。
比較的変更しても問題がないコマンド名と異なり、ファイル内のコンテンツの命名は変更するとblogsyncのユーザーがやはり困るなと考えた。
EditURLとEntryIdやURLとCustomPathは扱いの違いもあり命名を変えたほうがいいと考えたが、同じ挙動をするUpdatedプロパティはわざわざ変更するよりもblogsyncに合わせた命名をするほうがメリットが大きいはず