### PR TITLE
chore: `using ...Entry = ...`の形式のインポートを削除

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/Edit/EditEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditEntryTests.cs
@@ -1,6 +1,5 @@
 using UpHateblo.Lib.Entry.Edit;
 using UpHateblo.Lib.Tests.Shared;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using UpHateblo.Lib.Entry.Edit;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
+using UpHateblo.Lib.Entry.Read;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
@@ -1,6 +1,6 @@
+using UpHateblo.Lib.Entry.Edit;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryTests.cs
@@ -1,4 +1,4 @@
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
+using UpHateblo.Lib.Entry.Edit;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
@@ -1,6 +1,6 @@
+using UpHateblo.Lib.Entry.Edit;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Xml.Linq;
 using UpHateblo.Lib.Entry.List;
 using static UpHateblo.Lib.Shared.SchemaNamespaces;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
@@ -1,4 +1,4 @@
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
+using UpHateblo.Lib.Entry.List;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using UpHateblo.Lib.Entry.Post;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
+using UpHateblo.Lib.Entry.Read;
 
 namespace UpHateblo.Lib.Tests.Entry.Post;
 

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
@@ -1,6 +1,6 @@
+using UpHateblo.Lib.Entry.Edit;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.Post;
 

--- a/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryExtensionsTests.cs
@@ -1,5 +1,4 @@
 using UpHateblo.Lib.Entry.Read;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.Read;
 

--- a/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryTests.cs
@@ -1,4 +1,4 @@
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
+using UpHateblo.Lib.Entry.Read;
 
 namespace UpHateblo.Lib.Tests.Entry.Read;
 

--- a/UpHateblo.Lib.Tests/Entry/Read/ReadEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/ReadEntryTests.cs
@@ -1,6 +1,5 @@
 using UpHateblo.Lib.Entry.Read;
 using VYaml.Serialization;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
 
 namespace UpHateblo.Lib.Tests.Entry.Read;
 

--- a/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
+using UpHateblo.Lib.Entry.Read;
 
 namespace UpHateblo.Lib.Entry.Edit;
 

--- a/UpHateblo.Lib/Entry/Post/PostableEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostableEntry.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
-using EditableEntry = UpHateblo.Lib.Entry.Edit.EditableEntry;
-using FetchedEntry = UpHateblo.Lib.Entry.List.FetchedEntry;
-using MaybeEntry = UpHateblo.Lib.Entry.Read.MaybeEntry;
+using UpHateblo.Lib.Entry.Edit;
+using UpHateblo.Lib.Entry.List;
+using UpHateblo.Lib.Entry.Read;
 
 namespace UpHateblo.Lib.Entry.Post;
 


### PR DESCRIPTION
基本的に名前空間を用いた従来のインポートを行っていたが、フォルダ構造と名前空間の変更時に機械的な変換が行われた結果、この形式のインポート文がテストプロジェクトで散見された。本PRはこの形式のインポートを従来のインポートに修正するもの。