### PR TITLE
feat: PostEntryとEditEntryがFetchedEntryを返す機能

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/Edit/EditEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditEntryTests.cs
@@ -19,11 +19,20 @@ public class EditEntryTests : WebRequestTestBase
                       This is a test content of edit command.
                       Updated at {updated}
                       """,
-            CustomPath: null,
+            CustomPath: Guid.CreateVersion7().ToString(),
             Date: updated,
             Draft: true,
-            Preview: false
+            Preview: true
         );
-        await EditEntry.Run(HttpClient, BlogConfig, entry);
+        var fetched = await EditEntry.Run(HttpClient, BlogConfig, entry);
+
+        Assert.Equal(entry.EntryId, fetched.EntryId);
+        Assert.Equal(entry.Title, fetched.Title);
+        Assert.Equal(entry.Category, fetched.Category);
+        Assert.Equal(entry.Content, fetched.Content);
+        Assert.Equal(entry.CustomPath, fetched.CustomPath);
+        Assert.Equal(entry.Date, fetched.Date);
+        Assert.Equal(entry.Draft, fetched.Draft);
+        Assert.Equal(entry.Preview, fetched.Preview);
     }
 }

--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
@@ -1,6 +1,6 @@
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
@@ -1,6 +1,6 @@
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Xml.Linq;
-using UpHateblo.Lib.Entry.List;
+using UpHateblo.Lib.Entry.Shared;
 using static UpHateblo.Lib.Shared.SchemaNamespaces;
 
 namespace UpHateblo.Lib.Tests.Entry.List;

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
@@ -1,4 +1,4 @@
-using UpHateblo.Lib.Entry.List;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 

--- a/UpHateblo.Lib.Tests/Entry/Post/PostEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostEntryTests.cs
@@ -18,11 +18,20 @@ public class PostEntryTests : WebRequestTestBase
                       This is a test content of post command.
                       Posted at {updated}
                       """,
-            CustomPath: null,
+            CustomPath: Guid.CreateVersion7().ToString(),
             Date: updated,
             Draft: true,
             Preview: false
         );
-        await PostEntry.Run(HttpClient, BlogConfig, entry);
+        var fetched = await PostEntry.Run(HttpClient, BlogConfig, entry);
+
+        Assert.Equal(entry.Title, fetched.Title);
+        Assert.Equal(entry.Category, fetched.Category);
+        Assert.Equal(entry.Content, fetched.Content);
+        Assert.Equal(entry.CustomPath, fetched.CustomPath);
+        Assert.Equal(entry.Date, fetched.Date);
+        Assert.Equal(entry.Draft, fetched.Draft);
+        Assert.Equal(entry.Preview, fetched.Preview);
+        Assert.NotEmpty(fetched.EntryId);
     }
 }

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
@@ -1,6 +1,6 @@
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.Post;
 

--- a/UpHateblo.Lib/Entry/Edit/EditEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditEntry.cs
@@ -1,3 +1,5 @@
+using System.Xml.Linq;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Shared;
 using UpHateblo.Lib.Shared;
 
@@ -6,6 +8,7 @@ namespace UpHateblo.Lib.Entry.Edit;
 public static class EditEntry
 {
     public static async Task Run(
+    public static async Task<FetchedEntry> Run(
         HttpClient httpClient,
         BlogConfig blog,
         EditableEntry entry,
@@ -20,5 +23,11 @@ public static class EditEntry
 
         var res = await httpClient.SendAsync(request);
         res.EnsureSuccessStatusCode();
+
+        var content = await res.Content.ReadAsStringAsync();
+        var xml = XDocument.Parse(content);
+        var root = xml.Root!;
+        var fetchedEntry = FetchedEntrySchema.Deserialize(root);
+        return fetchedEntry;
     }
 }

--- a/UpHateblo.Lib/Entry/Edit/EditEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditEntry.cs
@@ -7,7 +7,8 @@ namespace UpHateblo.Lib.Entry.Edit;
 
 public static class EditEntry
 {
-    public static async Task Run(
+    /// <remarks>下書きではないエントリに対してプレビューフラグを指定しても無効。</remarks>
+    /// <remarks>一度プレビューフラグを有効にした場合、API経由でプレビューを無効にすることはできない。</remarks>
     public static async Task<FetchedEntry> Run(
         HttpClient httpClient,
         BlogConfig blog,

--- a/UpHateblo.Lib/Entry/Edit/EditEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditEntry.cs
@@ -1,5 +1,4 @@
 using System.Xml.Linq;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Shared;
 using UpHateblo.Lib.Shared;
 

--- a/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Post;
 using UpHateblo.Lib.Entry.Read;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Entry.Edit;
 

--- a/UpHateblo.Lib/Entry/List/ListEntry.cs
+++ b/UpHateblo.Lib/Entry/List/ListEntry.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using UpHateblo.Lib.Entry.Shared;
 using UpHateblo.Lib.Shared;
 using static UpHateblo.Lib.Shared.SchemaNamespaces;
 

--- a/UpHateblo.Lib/Entry/Post/PostEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostEntry.cs
@@ -7,7 +7,7 @@ namespace UpHateblo.Lib.Entry.Post;
 
 public static class PostEntry
 {
-    public static async Task Run(
+    /// <remarks>下書きではないエントリに対してプレビューフラグを指定しても無効。</remarks>
     public static async Task<FetchedEntry> Run(
         HttpClient httpClient,
         BlogConfig blog,

--- a/UpHateblo.Lib/Entry/Post/PostEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostEntry.cs
@@ -1,3 +1,5 @@
+using System.Xml.Linq;
+using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Shared;
 using UpHateblo.Lib.Shared;
 
@@ -6,6 +8,7 @@ namespace UpHateblo.Lib.Entry.Post;
 public static class PostEntry
 {
     public static async Task Run(
+    public static async Task<FetchedEntry> Run(
         HttpClient httpClient,
         BlogConfig blog,
         PostableEntry entry,
@@ -19,5 +22,11 @@ public static class PostEntry
 
         var res = await httpClient.SendAsync(request);
         res.EnsureSuccessStatusCode();
+
+        var content = await res.Content.ReadAsStringAsync();
+        var xml = XDocument.Parse(content);
+        var root = xml.Root!;
+        var fetchedEntry = FetchedEntrySchema.Deserialize(root);
+        return fetchedEntry;
     }
 }

--- a/UpHateblo.Lib/Entry/Post/PostEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostEntry.cs
@@ -1,5 +1,4 @@
 using System.Xml.Linq;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Shared;
 using UpHateblo.Lib.Shared;
 

--- a/UpHateblo.Lib/Entry/Post/PostableEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostableEntry.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.List;
 using UpHateblo.Lib.Entry.Read;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Entry.Post;
 

--- a/UpHateblo.Lib/Entry/Shared/FetchedEntry.cs
+++ b/UpHateblo.Lib/Entry/Shared/FetchedEntry.cs
@@ -2,7 +2,7 @@ using Equatable.Attributes;
 using UpHateblo.Lib.Entry.Edit;
 using UpHateblo.Lib.Entry.Post;
 
-namespace UpHateblo.Lib.Entry.List;
+namespace UpHateblo.Lib.Entry.Shared;
 
 [Equatable]
 public partial record FetchedEntry(

--- a/UpHateblo.Lib/Entry/Shared/FetchedEntrySchema.cs
+++ b/UpHateblo.Lib/Entry/Shared/FetchedEntrySchema.cs
@@ -3,7 +3,7 @@ using System.Xml;
 using System.Xml.Linq;
 using static UpHateblo.Lib.Shared.SchemaNamespaces;
 
-namespace UpHateblo.Lib.Entry.List;
+namespace UpHateblo.Lib.Entry.Shared;
 
 internal static class FetchedEntrySchema
 {


### PR DESCRIPTION
PostEntryとEditEntryの返り値がなかったために、投稿や編集したエントリーの結果について成功したか失敗したか以外を知るすべがなかった。
本PRではコマンドの処理内でレスポンスをパースしてFetchedEntryを返す機能を実装した。
関連してFetchedEntryとそのスキーマはPostEntryとEditEntryからも参照されるようになったため、共有空間に移動させた。