### PR TITLE
feat: FetchedEntryにPreviewURLプロパティを実装

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
@@ -19,7 +19,9 @@ public class EditableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex = Assert.Throws<ValidationException>(() => maybe.MaterializeEditable());
         Assert.Equal("Missing properties: EntryId", ex.Message);
@@ -38,7 +40,9 @@ public class EditableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex = Assert.Throws<ValidationException>(() => maybe.MaterializeEditable());
         Assert.Equal("Missing properties: Title, Category, Content, EntryId", ex.Message);
@@ -58,7 +62,9 @@ public class EditableEntryExtensionsTests
             Draft: true,
             Preview: false,
             Published: DateTime.Parse("2024-02-03T04:05:06Z").ToUniversalTime(),
-            ContentType: "text/x-markdown");
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
+        );
 
         var editable = maybe.MaterializeEditable();
 

--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryOperatorTests.cs
@@ -30,7 +30,8 @@ public class EditableEntryOperatorTests
             Draft: BaseEditable.Draft!.Value,
             Preview: BaseEditable.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.True(BaseEditable == fetched);
@@ -50,7 +51,8 @@ public class EditableEntryOperatorTests
             Draft: BaseEditable.Draft!.Value,
             Preview: BaseEditable.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.False(BaseEditable == fetchedDifferentCategory);
@@ -104,7 +106,8 @@ public class EditableEntryOperatorTests
             Draft: BaseEditable.Draft!.Value,
             Preview: BaseEditable.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.True(BaseEditable == fetched);

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryOperatorTests.cs
@@ -16,7 +16,8 @@ public class FetchedEntryOperatorTests
         Draft: false,
         Preview: false,
         Published: DateTime.Parse("2023-10-01"),
-        ContentType: "text/x-markdown"
+        ContentType: "text/x-markdown",
+        PreviewUrl: null
     );
 
     [Fact]

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntrySchemaTest.cs
@@ -122,6 +122,8 @@ public class FetchedEntrySchemaTest
             Assert.True(entry.Preview);
             Assert.Equal(DateTime.Parse("2022-09-27T15:55:17+09:00"), entry.Published);
             Assert.Equal("text/x-markdown", entry.ContentType);
+            Assert.Equal("https://kamome283.hatenablog.com/draft/entry/qESFitds1djAmaB3ZhwO8qCWhT4",
+                entry.PreviewUrl);
         }
 
         void TestHasCategories(FetchedEntry entry) =>

--- a/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/FetchedEntryTests.cs
@@ -14,7 +14,8 @@ public class FetchedEntryTests
         Draft: false,
         Preview: false,
         Published: DateTime.Parse("2023-10-01"),
-        ContentType: "text/x-markdown"
+        ContentType: "text/x-markdown",
+        PreviewUrl: null
     );
 
     [Fact]

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
@@ -19,7 +19,9 @@ public class PostableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex =
             Assert.Throws<ValidationException>(() => PostableEntryExtensions.Materialize(maybe));
@@ -39,7 +41,9 @@ public class PostableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex =
             Assert.Throws<ValidationException>(() => PostableEntryExtensions.Materialize(maybe));
@@ -59,7 +63,9 @@ public class PostableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex =
             Assert.Throws<ValidationException>(() => PostableEntryExtensions.Materialize(maybe));
@@ -79,7 +85,9 @@ public class PostableEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var ex =
             Assert.Throws<ValidationException>(() => PostableEntryExtensions.Materialize(maybe));
@@ -100,7 +108,9 @@ public class PostableEntryExtensionsTests
             Draft: true,
             Preview: false,
             Published: DateTime.Parse("2024-02-03T04:05:06Z").ToUniversalTime(),
-            ContentType: "text/x-markdown");
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
+        );
 
         var entry = PostableEntryExtensions.Materialize(maybe);
 

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryOperatorTests.cs
@@ -29,7 +29,8 @@ public class PostableEntryOperatorTests
             Draft: BaseEntry.Draft!.Value,
             Preview: BaseEntry.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.True(BaseEntry == fetched);
@@ -49,7 +50,8 @@ public class PostableEntryOperatorTests
             Draft: BaseEntry.Draft!.Value,
             Preview: BaseEntry.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.False(BaseEntry == fetchedDifferentCategory);
@@ -105,7 +107,8 @@ public class PostableEntryOperatorTests
             Draft: BaseEntry.Draft!.Value,
             Preview: BaseEntry.Preview!.Value,
             Published: DateTime.Parse("2023-10-01"),
-            ContentType: "text/x-markdown"
+            ContentType: "text/x-markdown",
+            PreviewUrl: null
         );
 
         Assert.True(BaseEntry == fetched);

--- a/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryExtensionsTests.cs
@@ -17,7 +17,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var right = new MaybeEntry(
             EntryId: null,
@@ -29,7 +31,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var merged = left.Merge(right);
 
@@ -50,7 +54,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e1 = new MaybeEntry(
             EntryId: null,
@@ -62,7 +68,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e2 = new MaybeEntry(
             EntryId: null,
@@ -74,7 +82,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e3 = new MaybeEntry(
             EntryId: null,
@@ -86,7 +96,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var merged = left.Merge(e1, e2, e3);
 
@@ -106,7 +118,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e1 = new MaybeEntry(
             EntryId: null,
@@ -118,7 +132,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e2 = new MaybeEntry(
             EntryId: null,
@@ -130,7 +146,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var merged = left.Merge(e1, e2);
 
@@ -150,7 +168,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var e1 = new MaybeEntry(
             EntryId: "id-1",
@@ -162,7 +182,9 @@ public class MaybeEntryExtensionsTests
             Draft: true,
             Preview: null,
             Published: null,
-            ContentType: "text/x-markdown");
+            ContentType: "text/x-markdown",
+            PreviewUrl: "https://example.com/preview"
+        );
 
         var e2 = new MaybeEntry(
             EntryId: null,
@@ -174,7 +196,9 @@ public class MaybeEntryExtensionsTests
             Draft: null,
             Preview: true,
             Published: DateTime.Parse("2024-01-01"),
-            ContentType: null);
+            ContentType: null,
+            PreviewUrl: null
+        );
 
         var merged = left.Merge(e1, e2);
 
@@ -188,5 +212,6 @@ public class MaybeEntryExtensionsTests
         Assert.True(merged.Preview);
         Assert.Equal(DateTime.Parse("2024-01-01"), merged.Published);
         Assert.Equal("text/x-markdown", merged.ContentType);
+        Assert.Equal("https://example.com/preview", merged.PreviewUrl);
     }
 }

--- a/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/MaybeEntryTests.cs
@@ -14,7 +14,8 @@ public class MaybeEntryTests
         Draft: false,
         Preview: false,
         Published: DateTime.Parse("2023-10-01"),
-        ContentType: "text/html"
+        ContentType: "text/html",
+        PreviewUrl: null
     );
 
     [Fact]

--- a/UpHateblo.Lib.Tests/Entry/Read/ReadEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Read/ReadEntryTests.cs
@@ -25,9 +25,10 @@ public class ReadEntryTests
             CustomPath: "test/url-path",
             Date: DateTime.Parse("2025-01-09T19:07:00+09:00"),
             Draft: true,
-            Preview: false,
+            Preview: true,
             Published: null,
-            ContentType: null
+            ContentType: null,
+            PreviewUrl: "https://example.com/preview/url"
         );
         string content = """
                          ---
@@ -38,7 +39,8 @@ public class ReadEntryTests
                          Date: 2025-01-09T19:07:00+09:00
                          CustomPath: test/url-path
                          Draft: true
-                         Preview: false
+                         Preview: true
+                         PreviewUrl: https://example.com/preview/url
                          ---
                          This is a test,
                          and this is the second line of the content.
@@ -79,7 +81,8 @@ public class ReadEntryTests
             Draft: null,
             Preview: null,
             Published: null,
-            ContentType: null
+            ContentType: null,
+            PreviewUrl: null
         );
         var actual = ReadEntry.Run(content);
         Assert.Equal(expected, actual);

--- a/UpHateblo.Lib/Entry/Read/MaybeEntry.cs
+++ b/UpHateblo.Lib/Entry/Read/MaybeEntry.cs
@@ -18,7 +18,8 @@ public partial record MaybeEntry(
     bool? Draft,
     bool? Preview,
     DateTime? Published,
-    string? ContentType
+    string? ContentType,
+    string? PreviewUrl
 );
 
 public static class MaybeEntryExtensions
@@ -38,10 +39,12 @@ public static class MaybeEntryExtensions
             var preview = result.Preview ?? e.Preview;
             var published = result.Published ?? e.Published;
             var contentType = result.ContentType ?? e.ContentType;
+            var previewUrl = result.PreviewUrl ?? e.PreviewUrl;
 
             result = new MaybeEntry(EntryId: entryId, Title: title, Category: category,
                 Content: content, CustomPath: customPath, Date: date, Draft: draft,
-                Preview: preview, Published: published, ContentType: contentType);
+                Preview: preview, Published: published, ContentType: contentType,
+                PreviewUrl: previewUrl);
         }
 
         return result;

--- a/UpHateblo.Lib/Entry/Read/ReadEntry.cs
+++ b/UpHateblo.Lib/Entry/Read/ReadEntry.cs
@@ -23,7 +23,7 @@ public static class ReadEntry
         var (maybeFrontMatter, body) = content.Separate();
         var frontMatter = maybeFrontMatter is not null
             ? maybeFrontMatter.ParseFrontMatter()
-            : new MaybeEntry(null, null, null, null, null, null, null, null, null, null);
+            : new MaybeEntry(null, null, null, null, null, null, null, null, null, null, null);
         return frontMatter with { Content = body };
     }
 

--- a/UpHateblo.Lib/Entry/Shared/FetchedEntry.cs
+++ b/UpHateblo.Lib/Entry/Shared/FetchedEntry.cs
@@ -15,7 +15,8 @@ public partial record FetchedEntry(
     bool Draft,
     bool Preview,
     DateTime Published,
-    string ContentType
+    string ContentType,
+    string? PreviewUrl
 )
 {
     public static bool operator ==(FetchedEntry fetched, EditableEntry editable)

--- a/UpHateblo.Lib/Entry/Shared/FetchedEntrySchema.cs
+++ b/UpHateblo.Lib/Entry/Shared/FetchedEntrySchema.cs
@@ -27,7 +27,8 @@ internal static class FetchedEntrySchema
                 Draft: entryElement.ParseDraft(),
                 Preview: entryElement.ParseAbsolutePreview(),
                 Published: entryElement.ParsePublished(),
-                ContentType: contentType
+                ContentType: contentType,
+                PreviewUrl: entryElement.ParsePreviewUrl()
             );
             return entry;
         }
@@ -83,6 +84,13 @@ internal static class FetchedEntrySchema
     private static DateTime ParsePublished(this XElement root)
     {
         return DateTime.Parse(root.Element(AtomNs + "published")!.Value);
+    }
+
+    private static string? ParsePreviewUrl(this XElement root)
+    {
+        var node = root.Elements(AtomNs + "link")
+            .FirstOrDefault(x => x.Attribute("rel")?.Value == "preview");
+        return node?.Attribute("href")!.Value;
     }
 
     private static (string Content, string ContentType) ParseContentAndType(this XElement root)


### PR DESCRIPTION
PreviewURLはレスポンスのボディに含まれていたが存在を無視していた。
しかし、それほど手間でもないし実装しておこうかということで実装した。