### PR TITLE
chore: FetchedEntry関連のテストをListからSharedに移動

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntryOperatorTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntryOperatorTests.cs
@@ -2,7 +2,7 @@ using UpHateblo.Lib.Entry.Edit;
 using UpHateblo.Lib.Entry.Post;
 using UpHateblo.Lib.Entry.Shared;
 
-namespace UpHateblo.Lib.Tests.Entry.List;
+namespace UpHateblo.Lib.Tests.Entry.Shared;
 
 public class FetchedEntryOperatorTests
 {

--- a/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntrySchemaTest.cs
+++ b/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntrySchemaTest.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 using UpHateblo.Lib.Entry.Shared;
 using static UpHateblo.Lib.Shared.SchemaNamespaces;
 
-namespace UpHateblo.Lib.Tests.Entry.List;
+namespace UpHateblo.Lib.Tests.Entry.Shared;
 
 public class FetchedEntrySchemaTest
 {

--- a/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Shared/FetchedEntryTests.cs
@@ -1,6 +1,6 @@
 using UpHateblo.Lib.Entry.Shared;
 
-namespace UpHateblo.Lib.Tests.Entry.List;
+namespace UpHateblo.Lib.Tests.Entry.Shared;
 
 public class FetchedEntryTests
 {


### PR DESCRIPTION
以前の作業でFetchedEntry関連の実装はSharedに移動されたが、それに関連するテストをSharedに移動するのを忘れていた。
本PRはそれらのファイルの移動と名前空間の変更