### PR TITLE
refactor: Webリクエストのあるテストを改善

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/List/ListEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/List/ListEntryTests.cs
@@ -1,14 +1,31 @@
 using UpHateblo.Lib.Entry.List;
+using UpHateblo.Lib.Entry.Post;
+using UpHateblo.Lib.Tests.Entry.Shared;
 using UpHateblo.Lib.Tests.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.List;
 
 public class ListEntryTests : WebRequestTestBase
 {
+    public ListEntryTests()
+    {
+        foreach (var _ in Enumerable.Range(0, 10))
+        {
+            PostAndQueueEntry().Wait();
+        }
+    }
+
     [Fact]
     public async Task ItCanListEntries()
     {
         var entries = await ListEntry.Run(HttpClient, BlogConfig);
         Assert.Contains(entries, e => e.EntryId == FixedTargetEntryId);
+    }
+
+    private async Task PostAndQueueEntry()
+    {
+        var entry = EntityExamples.PostableEntryExample();
+        var res = await PostEntry.Run(HttpClient, BlogConfig, entry);
+        EntryIdsToDispose.Enqueue(res.EntryId);
     }
 }

--- a/UpHateblo.Lib.Tests/Entry/Post/PostEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostEntryTests.cs
@@ -11,6 +11,7 @@ public class PostEntryTests : WebRequestTestBase
     {
         var entry = EntityExamples.PostableEntryExample();
         var fetched = await PostEntry.Run(HttpClient, BlogConfig, entry);
+        EntryIdsToDispose.Enqueue(fetched.EntryId);
 
         Assert.Equal(entry.Title, fetched.Title);
         Assert.Equal(entry.Category, fetched.Category);

--- a/UpHateblo.Lib.Tests/Shared/WebRequestTestBase.cs
+++ b/UpHateblo.Lib.Tests/Shared/WebRequestTestBase.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using UpHateblo.Lib.Entry.Delete;
 using UpHateblo.Lib.Shared;
 
 namespace UpHateblo.Lib.Tests.Shared;
@@ -9,12 +10,15 @@ public record BlogConfigSecrets(BlogConfig Blog);
 
 [Collection("WebRequest")]
 [Trait("Category", "WebRequest")]
-public abstract class WebRequestTestBase
+public abstract class WebRequestTestBase : IDisposable
 {
     // TODO: このプロパティはEntryのコマンドに関するものなので、より適切な場所に移動させたい
     // この名前空間のテストは結合テストでないので、テスト対象のエントリーは決め打ちにしている
     protected const string FixedTargetEntryId = "6802888565257240236";
     protected static readonly HttpClient HttpClient = new();
+
+    // 複数回Disposeが呼ばれても問題ないようにQueueで管理する
+    protected readonly Queue<string> EntryIdsToDispose = [];
 
     protected WebRequestTestBase()
     {
@@ -29,4 +33,14 @@ public abstract class WebRequestTestBase
     }
 
     protected BlogConfig BlogConfig { get; }
+
+    public void Dispose()
+    {
+        while (EntryIdsToDispose.TryDequeue(out var entryId))
+        {
+            // Task.WaitAllは一度にすべてのリクエストを送ってしまうのでサーバーに負荷をかけてしまう。
+            // そのため一件ずつDeleteEntryを走らせている
+            DeleteEntry.Run(HttpClient, BlogConfig, entryId).Wait();
+        }
+    }
 }

--- a/UpHateblo.Lib.Tests/Shared/WebRequestTestBase.cs
+++ b/UpHateblo.Lib.Tests/Shared/WebRequestTestBase.cs
@@ -7,6 +7,7 @@ namespace UpHateblo.Lib.Tests.Shared;
 // ReSharper disable once NotAccessedPositionalProperty.Global
 public record BlogConfigSecrets(BlogConfig Blog);
 
+[Collection("WebRequest")]
 [Trait("Category", "WebRequest")]
 public abstract class WebRequestTestBase
 {


### PR DESCRIPTION
- テストコレクションを作成してWebリクエストのあるテストを直列実行するように変更
- 特定のキューのエントリーを削除する後処理を作成し、実環境に影響が少なくなるようにした。