### PR TITLE
feat: StringifyEntryコマンドの追加

### DIFF
--- a/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Edit/EditableEntryExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.Parse;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.Edit;
 

--- a/UpHateblo.Lib.Tests/Entry/Parse/ParseEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Parse/ParseEntryTests.cs
@@ -1,4 +1,5 @@
 using UpHateblo.Lib.Entry.Parse;
+using UpHateblo.Lib.Entry.Shared;
 using VYaml.Serialization;
 
 namespace UpHateblo.Lib.Tests.Entry.Parse;

--- a/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Post/PostableEntryExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using UpHateblo.Lib.Entry.Parse;
 using UpHateblo.Lib.Entry.Post;
+using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Tests.Entry.Post;
 

--- a/UpHateblo.Lib.Tests/Entry/Shared/MaybeEntryExtensionsTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Shared/MaybeEntryExtensionsTests.cs
@@ -1,6 +1,6 @@
-using UpHateblo.Lib.Entry.Parse;
+using UpHateblo.Lib.Entry.Shared;
 
-namespace UpHateblo.Lib.Tests.Entry.Parse;
+namespace UpHateblo.Lib.Tests.Entry.Shared;
 
 public class MaybeEntryExtensionsTests
 {

--- a/UpHateblo.Lib.Tests/Entry/Shared/MaybeEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Shared/MaybeEntryTests.cs
@@ -1,6 +1,6 @@
-using UpHateblo.Lib.Entry.Parse;
+using UpHateblo.Lib.Entry.Shared;
 
-namespace UpHateblo.Lib.Tests.Entry.Parse;
+namespace UpHateblo.Lib.Tests.Entry.Shared;
 
 public class MaybeEntryTests
 {

--- a/UpHateblo.Lib.Tests/Entry/Stringify/StringifyEntryTests.cs
+++ b/UpHateblo.Lib.Tests/Entry/Stringify/StringifyEntryTests.cs
@@ -1,0 +1,134 @@
+using UpHateblo.Lib.Entry.Parse;
+using UpHateblo.Lib.Entry.Shared;
+using UpHateblo.Lib.Entry.Stringify;
+
+namespace UpHateblo.Lib.Tests.Entry.Stringify;
+
+public class StringifyEntryTests
+{
+    [Fact]
+    public void ItSerializesBodyOnlyWithoutFrontMatter()
+    {
+        // Arrange
+        var entry = new MaybeEntry(
+            EntryId: null,
+            Title: null,
+            Category: null,
+            Content: """
+                     Hello world!
+                     This is body only.
+                     """,
+            CustomPath: null,
+            Date: null,
+            Draft: null,
+            Preview: null,
+            Published: null,
+            ContentType: null,
+            PreviewUrl: null
+        );
+
+        // Act
+        var actual = StringifyEntry.Run(entry);
+
+        // Assert: no front matter should be emitted if all header fields are null
+        Assert.Equal(entry.Content, actual);
+        Assert.DoesNotContain("---", actual);
+    }
+
+    [Fact]
+    public void ItSerializesFullSpecEntryAndRoundTripsThroughParser()
+    {
+        // Arrange: mirrors ParseEntryTests.ItCanDeserializeFullSpecMarkdown
+        var original = new MaybeEntry(
+            EntryId: null,
+            Title: "FullSpecMarkdown",
+            Category: ["A", "B"],
+            Content: """
+                     This is a test,
+                     and this is the second line of the content.
+                     """,
+            CustomPath: "test/url-path",
+            Date: DateTime.Parse("2025-01-09T19:07:00+09:00"),
+            Draft: true,
+            Preview: true,
+            Published: null,
+            ContentType: null,
+            PreviewUrl: "https://example.com/preview/url"
+        );
+
+        // Act
+        var text = StringifyEntry.Run(original);
+        var parsed = ParseEntry.Run(text);
+
+        // Assert: round-trip equals original
+        Assert.Equal(original, parsed);
+
+        // And sanity-check that front matter markers exist when header has values
+        Assert.StartsWith("---", text.TrimStart());
+        Assert.Contains("Title: FullSpecMarkdown", text);
+    }
+
+    [Fact]
+    public void ItEmitsFrontMatterWhenAnyHeaderFieldExists()
+    {
+        var original = new MaybeEntry(
+            EntryId: null,
+            Title: "TitleOnly",
+            Category: null,
+            Content: "Body",
+            CustomPath: null,
+            Date: null,
+            Draft: null,
+            Preview: null,
+            Published: null,
+            ContentType: null,
+            PreviewUrl: null
+        );
+
+        var text = StringifyEntry.Run(original);
+
+        // Should contain YAML front matter block with separators
+        // We don't assert exact YAML layout, only the presence of separators and the key text
+        Assert.Contains("\n---\n", "\n" + text); // opening separator on its own line
+        Assert.Contains("Title: TitleOnly", text);
+        Assert.Contains("\n---\n",
+            text[
+                (text.IndexOf("Title: TitleOnly",
+                    StringComparison.Ordinal))..]); // closing separator exists after some YAML
+
+        // And it must be parseable back to the same entry
+        var parsed = ParseEntry.Run(text);
+        Assert.Equal(original, parsed);
+    }
+
+    [Fact]
+    public void ItRoundTripsVariousMinimalCases()
+    {
+        var cases = new[]
+        {
+            new MaybeEntry(null, null, null, "Body only", null, null, null, null, null, null, null),
+            new MaybeEntry(null, "T", null, "Body", null, null, null, null, null, null, null),
+            new MaybeEntry(
+                EntryId: null,
+                Title: null,
+                Category: ["tag1", "tag2"],
+                Content: "Body",
+                CustomPath: null,
+                Date: null,
+                Draft: null,
+                Preview: null,
+                Published: null,
+                ContentType: null,
+                PreviewUrl: null),
+            new MaybeEntry(null, null, null, "Body", "custom/path",
+                DateTime.Parse("2024-12-31T23:59:59+00:00"), false, true, null, null, null),
+        };
+
+        foreach (var original in cases)
+        {
+            var text = StringifyEntry.Run(original);
+            var parsed = ParseEntry.Run(text);
+            Assert.Equal(original, parsed);
+        }
+    }
+}

--- a/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
+++ b/UpHateblo.Lib/Entry/Edit/EditableEntry.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
-using UpHateblo.Lib.Entry.Parse;
 using UpHateblo.Lib.Entry.Post;
 using UpHateblo.Lib.Entry.Shared;
 

--- a/UpHateblo.Lib/Entry/Parse/ParseEntry.cs
+++ b/UpHateblo.Lib/Entry/Parse/ParseEntry.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using UpHateblo.Lib.Entry.Shared;
 using VYaml.Annotations;
 using VYaml.Serialization;
 

--- a/UpHateblo.Lib/Entry/Parse/ParseEntry.cs
+++ b/UpHateblo.Lib/Entry/Parse/ParseEntry.cs
@@ -8,6 +8,7 @@ namespace UpHateblo.Lib.Entry.Parse;
 
 public static class ParseEntry
 {
+    /// <remarks>StringifyEntryでも同じコードを書いているけど2箇所なら共通化しなくてもいいや</remarks>
     private static readonly YamlSerializerOptions YamlSerializerOptions =
         new() { NamingConvention = NamingConvention.UpperCamelCase };
 

--- a/UpHateblo.Lib/Entry/Post/PostableEntry.cs
+++ b/UpHateblo.Lib/Entry/Post/PostableEntry.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Equatable.Attributes;
 using UpHateblo.Lib.Entry.Edit;
-using UpHateblo.Lib.Entry.Parse;
 using UpHateblo.Lib.Entry.Shared;
 
 namespace UpHateblo.Lib.Entry.Post;

--- a/UpHateblo.Lib/Entry/Shared/MaybeEntry.cs
+++ b/UpHateblo.Lib/Entry/Shared/MaybeEntry.cs
@@ -1,7 +1,7 @@
 using Equatable.Attributes;
 using VYaml.Annotations;
 
-namespace UpHateblo.Lib.Entry.Parse;
+namespace UpHateblo.Lib.Entry.Shared;
 
 /// <summary>
 ///     ファイルやCLIのパラメーターから読み出すエントリーの断片

--- a/UpHateblo.Lib/Entry/Stringify/StringifyEntry.cs
+++ b/UpHateblo.Lib/Entry/Stringify/StringifyEntry.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using UpHateblo.Lib.Entry.Shared;
+using VYaml.Annotations;
+using VYaml.Serialization;
+
+namespace UpHateblo.Lib.Entry.Stringify;
+
+public static class StringifyEntry
+{
+    /// <remarks>ParseEntryでも同じコードを書いているけど2箇所なら共通化しなくてもいいや</remarks>
+    private static readonly YamlSerializerOptions YamlSerializerOptions =
+        new() { NamingConvention = NamingConvention.UpperCamelCase };
+
+    public static string Run(MaybeEntry entry)
+    {
+        var frontMatter = entry.FrontMatter();
+        var content = entry.Content;
+        var components = new[] { frontMatter, content }.Where(x => x is not null).Select(x => x!);
+        return string.Join(Environment.NewLine, components);
+    }
+
+    /// <remarks>
+    /// VYamlはnullのプロパティを無視せずに、
+    /// ex.) Title: null
+    /// のように書き込む。
+    /// この挙動を無効化するために、動的に作成した辞書をシリアライズしている。
+    /// </remarks>
+    private static string? FrontMatter(this MaybeEntry entry)
+    {
+        var header = entry with { Content = null };
+
+        var props = header.GetProps();
+        if (props.Count == 0) return null;
+
+        var yamlBytes = YamlSerializer.Serialize(header.GetProps(), YamlSerializerOptions);
+        var yaml = Encoding.UTF8.GetString(yamlBytes.Span);
+        return $"""
+                ---
+                {yaml}
+                ---
+                """;
+    }
+
+    [RequiresDynamicCode("Current implementation uses reflection to get properties.")]
+    private static Dictionary<string, object> GetProps(this MaybeEntry entry)
+    {
+        Dictionary<string, object> result = new();
+        var props = typeof(MaybeEntry).GetProperties();
+        foreach (var prop in props)
+        {
+            var value = prop.GetValue(entry);
+            if (value is null) continue;
+            // VYamlはHashSet<string>をプリミティブにサポートしていないので、string[]に変換
+            var maybeSet = value as HashSet<string>;
+            result[prop.Name] = maybeSet?.ToArray() ?? value;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
nullなプロパティをヘッダーに残さないようにする処理に改善の余地あり
ただこの改善をするにはVYamlにコントリビュートする必要があるので、現時点で動作するコードを残しておく